### PR TITLE
fix(core): typos in useObject test titles

### DIFF
--- a/tests/core-unittest/src/useObject.spec.tsx
+++ b/tests/core-unittest/src/useObject.spec.tsx
@@ -5,7 +5,7 @@ import userEvent from '@testing-library/user-event';
 import { describeWithStrict } from '../util/describeWithStrict';
 
 describeWithStrict('Sugar#useObject', () => {
-  test('useObject should propagates onChange event', async () => {
+  test('useObject should propagate onChange event', async () => {
     const { result: sugar } = renderHook(() =>
       useForm({ template: { a: '', b: '' } })
     );
@@ -34,7 +34,7 @@ describeWithStrict('Sugar#useObject', () => {
     });
   });
 
-  test('useObject should propagates onBlur event', async () => {
+  test('useObject should propagate onBlur event', async () => {
     const { result: sugar } = renderHook(() =>
       useForm({ template: { a: '', b: '' } })
     );


### PR DESCRIPTION
## Summary
- fix wording in `useObject.spec.tsx` test titles

## Testing
- `pnpm exec vitest run tests/core-unittest/src/useObject.spec.tsx` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-10.11.0.tgz)*

------
https://chatgpt.com/codex/tasks/task_e_6846cd7937b48323b994d6a022d8d005