### PR TITLE
feat(core): handle destroy before ready

### DIFF
--- a/packages/core/src/sugar/index.ts
+++ b/packages/core/src/sugar/index.ts
@@ -139,10 +139,21 @@ export class SugarInner<T extends SugarValue> {
   }
 
   destroy() {
-    if (this.status.status === 'ready') {
-      this.status = {
-        status: 'unavailable',
-      };
+    switch (this.status.status) {
+      case 'ready':
+        this.status = {
+          status: 'unavailable',
+        };
+        break;
+      case 'unready':
+        this.status.resolveGetPromise({ result: 'unavailable' });
+        this.status.resolveSetPromise({ result: 'unavailable' });
+        this.status = {
+          status: 'unavailable',
+        };
+        break;
+      case 'unavailable':
+        break;
     }
   }
 

--- a/packages/core/src/sugar/index.ts
+++ b/packages/core/src/sugar/index.ts
@@ -123,12 +123,13 @@ export class SugarInner<T extends SugarValue> {
       if (this.status.lock) {
         return;
       }
-      this.status.lock = true;
+      const status = this.status;
+      status.lock = true;
 
-      this.status.resolveSetPromise(
-        await setter(this.status.recentValue ?? this.template)
+      status.resolveSetPromise(
+        await setter(status.recentValue ?? this.template)
       );
-      this.status.resolveGetPromise(await getter());
+      status.resolveGetPromise(await getter());
     }
 
     this.status = {
@@ -146,8 +147,10 @@ export class SugarInner<T extends SugarValue> {
         };
         break;
       case 'unready':
-        this.status.resolveGetPromise({ result: 'unavailable' });
-        this.status.resolveSetPromise({ result: 'unavailable' });
+        if (!this.status.lock) {
+          this.status.resolveGetPromise({ result: 'unavailable' });
+          this.status.resolveSetPromise({ result: 'unavailable' });
+        }
         this.status = {
           status: 'unavailable',
         };

--- a/tests/core-unittest/src/destroyBeforeReady.spec.tsx
+++ b/tests/core-unittest/src/destroyBeforeReady.spec.tsx
@@ -1,0 +1,22 @@
+import { useForm } from '@sugarform/core';
+import { renderHook } from '@testing-library/react';
+import { expect, test } from 'vitest';
+import { describeWithStrict } from '../util/describeWithStrict';
+import { checkPending } from '../util/checkPending';
+
+describeWithStrict('Sugar#destroy before ready', () => {
+  test('destroy resolves pending promises', async () => {
+    const { result } = renderHook(() => useForm<string>({ template: '' }));
+
+    const getPromise = result.current.get();
+    const setPromise = result.current.set('test');
+
+    expect(await checkPending(getPromise)).toStrictEqual({ resolved: false });
+    expect(await checkPending(setPromise)).toStrictEqual({ resolved: false });
+
+    result.current.destroy();
+
+    await expect(getPromise).resolves.toStrictEqual({ result: 'unavailable' });
+    await expect(setPromise).resolves.toStrictEqual({ result: 'unavailable' });
+  });
+});


### PR DESCRIPTION
## Summary
- implement `destroy()` handling for unready state and resolve pending promises
- add regression test covering destroy before ready

## Testing
- `pnpm --filter ./tests/core-unittest test --run` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-10.11.0.tgz)*

------
https://chatgpt.com/codex/tasks/task_e_6846cd8e63c48323bc464d12d946e9d4