### PR TITLE
feat(core): Add `Sugar#useValidation` hook

### DIFF
--- a/packages/core/src/lib.ts
+++ b/packages/core/src/lib.ts
@@ -1,4 +1,4 @@
 export { useForm } from './form';
 export { TextInput } from './components/textInput';
 export { NumberInput } from './components/numberInput';
-export type { Sugar } from './sugar/types';
+export type { Sugar, ValidationPhase } from './sugar/types';

--- a/packages/core/src/sugar/index.ts
+++ b/packages/core/src/sugar/index.ts
@@ -79,17 +79,15 @@ export class SugarInner<T extends SugarValue> {
       case 'unready':
         return this.status.getPromise;
       case 'ready':
-        return this.status
-          .getter()
-          .then(async (res) => {
-            if (res.result === 'success' && submit) {
-              const ok = await this.runValidators(res.value, 'submit');
-              if (!ok) {
-                return { result: 'validation_fault' } as SugarGetResult<T>;
-              }
+        return this.status.getter().then(async (res) => {
+          if (res.result === 'success' && submit) {
+            const ok = await this.runValidators(res.value, 'submit');
+            if (!ok) {
+              return { result: 'validation_fault' } as SugarGetResult<T>;
             }
-            return res;
-          });
+          }
+          return res;
+        });
     }
   }
 
@@ -113,7 +111,9 @@ export class SugarInner<T extends SugarValue> {
     (value: T, phase: ValidationPhase) => Promise<boolean>
   > = new Set();
 
-  addValidator(validator: (value: T, phase: ValidationPhase) => Promise<boolean>) {
+  addValidator(
+    validator: (value: T, phase: ValidationPhase) => Promise<boolean>
+  ) {
     this.validators.add(validator);
   }
 
@@ -123,7 +123,10 @@ export class SugarInner<T extends SugarValue> {
     this.validators.delete(validator);
   }
 
-  private async runValidators(value: T, phase: ValidationPhase): Promise<boolean> {
+  private async runValidators(
+    value: T,
+    phase: ValidationPhase
+  ): Promise<boolean> {
     if (this.validators.size === 0) {
       return true;
     }
@@ -205,9 +208,5 @@ export class SugarInner<T extends SugarValue> {
       value: T,
       fail: (reason: V, phase?: ValidationPhase) => void | Promise<void>
     ) => void | Promise<void>
-  ) =>
-    useValidation(this as Sugar<T>, validator)) as SugarUseValidation<
-    T,
-    V
-  >;
+  ) => useValidation(this as Sugar<T>, validator)) as SugarUseValidation<T, V>;
 }

--- a/packages/core/src/sugar/index.ts
+++ b/packages/core/src/sugar/index.ts
@@ -13,7 +13,7 @@ import {
   ValidationPhase,
 } from './types';
 import { useObject } from './useObject';
-import { useValidation } from './useValidation';
+import { useValidation as useValidationHook } from './useValidation';
 
 export class SugarInner<T extends SugarValue> {
   // Sugarは、get/setができるようになるまでに、Reactのレンダリングを待つ必要があります。
@@ -203,10 +203,12 @@ export class SugarInner<T extends SugarValue> {
   useObject: SugarUseObject<T> = (() =>
     useObject(this as Sugar<SugarValueObject>)) as SugarUseObject<T>;
 
-  useValidation: SugarUseValidation<T, unknown> = (<V>(
+  useValidation<V>(
     validator: (
       value: T,
       fail: (reason: V, phase?: ValidationPhase) => void | Promise<void>
     ) => void | Promise<void>
-  ) => useValidation(this as Sugar<T>, validator)) as SugarUseValidation<T, V>;
+  ): V[] {
+    return useValidationHook(this as Sugar<T>, validator);
+  }
 }

--- a/packages/core/src/sugar/index.ts
+++ b/packages/core/src/sugar/index.ts
@@ -7,10 +7,13 @@ import {
   SugarSetResult,
   SugarSetter,
   SugarUseObject,
+  SugarUseValidation,
   SugarValue,
   SugarValueObject,
+  ValidationPhase,
 } from './types';
 import { useObject } from './useObject';
+import { useValidation } from './useValidation';
 
 export class SugarInner<T extends SugarValue> {
   // Sugarは、get/setができるようになるまでに、Reactのレンダリングを待つ必要があります。
@@ -67,7 +70,7 @@ export class SugarInner<T extends SugarValue> {
     this.template = template;
   }
 
-  get(): Promise<SugarGetResult<T>> {
+  get(submit: boolean = false): Promise<SugarGetResult<T>> {
     switch (this.status.status) {
       case 'unavailable':
         return Promise.resolve({
@@ -76,7 +79,17 @@ export class SugarInner<T extends SugarValue> {
       case 'unready':
         return this.status.getPromise;
       case 'ready':
-        return this.status.getter();
+        return this.status
+          .getter()
+          .then(async (res) => {
+            if (res.result === 'success' && submit) {
+              const ok = await this.runValidators(res.value, 'submit');
+              if (!ok) {
+                return { result: 'validation_fault' } as SugarGetResult<T>;
+              }
+            }
+            return res;
+          });
     }
   }
 
@@ -95,6 +108,30 @@ export class SugarInner<T extends SugarValue> {
   }
 
   private eventTarget: EventTarget = new EventTarget();
+
+  private validators: Set<
+    (value: T, phase: ValidationPhase) => Promise<boolean>
+  > = new Set();
+
+  addValidator(validator: (value: T, phase: ValidationPhase) => Promise<boolean>) {
+    this.validators.add(validator);
+  }
+
+  removeValidator(
+    validator: (value: T, phase: ValidationPhase) => Promise<boolean>
+  ) {
+    this.validators.delete(validator);
+  }
+
+  private async runValidators(value: T, phase: ValidationPhase): Promise<boolean> {
+    if (this.validators.size === 0) {
+      return true;
+    }
+    const results = await Promise.all(
+      [...this.validators].map((v) => v(value, phase))
+    );
+    return results.every((r) => r);
+  }
 
   addEventListener<K extends keyof SugarEvent<T>>(
     type: K,
@@ -162,4 +199,15 @@ export class SugarInner<T extends SugarValue> {
 
   useObject: SugarUseObject<T> = (() =>
     useObject(this as Sugar<SugarValueObject>)) as SugarUseObject<T>;
+
+  useValidation: SugarUseValidation<T, unknown> = (<V>(
+    validator: (
+      value: T,
+      fail: (reason: V, phase?: ValidationPhase) => void | Promise<void>
+    ) => void | Promise<void>
+  ) =>
+    useValidation(this as Sugar<T>, validator)) as SugarUseValidation<
+    T,
+    V
+  >;
 }

--- a/packages/core/src/sugar/types.ts
+++ b/packages/core/src/sugar/types.ts
@@ -44,6 +44,12 @@ type SugarType<T extends SugarValue> = {
   ready: (getter: SugarGetter<T>, setter: SugarSetter<T>) => Promise<void>;
   destroy: () => void;
   useObject: SugarUseObject<T>;
+  useValidation: <V>(
+    validator: (
+      value: T,
+      fail: (reason: V, phase?: ValidationPhase) => void | Promise<void>
+    ) => void | Promise<void>
+  ) => V[];
   addEventListener: <K extends keyof SugarEvent<T>>(
     type: K,
     listener: CustomEventListener<SugarEvent<T>[K]>
@@ -72,3 +78,12 @@ export type SugarEvent<_T extends SugarValue> = {
   change: undefined;
   blur: undefined;
 };
+
+export type ValidationPhase = 'input' | 'blur' | 'submit';
+
+export type SugarUseValidation<T extends SugarValue, V> = (
+  validator: (
+    value: T,
+    fail: (reason: V, phase?: ValidationPhase) => void | Promise<void>
+  ) => void | Promise<void>
+) => V[];

--- a/packages/core/src/sugar/useValidation.ts
+++ b/packages/core/src/sugar/useValidation.ts
@@ -1,0 +1,65 @@
+import { useEffect, useRef, useState } from 'react';
+import { Sugar } from './types';
+import type { ValidationPhase } from './types';
+import { SugarInner } from '.';
+
+const phaseWeight: Record<ValidationPhase, number> = {
+  input: 0,
+  blur: 1,
+  submit: 2,
+};
+
+export function useValidation<T, V>(
+  sugar: Sugar<T>,
+  validator: (
+    value: T,
+    fail: (reason: V, phase?: ValidationPhase) => void | Promise<void>
+  ) => void | Promise<void>
+): V[] {
+  const validatorRef = useRef(validator);
+  validatorRef.current = validator;
+
+  const [validations, setValidations] = useState<V[]>([]);
+
+  const run = async (value: T, phase: ValidationPhase): Promise<boolean> => {
+    const fails: V[] = [];
+    const fail = (v: V, p: ValidationPhase = 'submit') => {
+      if (phaseWeight[phase] >= phaseWeight[p]) {
+        fails.push(v);
+      }
+    };
+    await validatorRef.current(value, fail);
+    setValidations(fails);
+    return fails.length === 0;
+  };
+
+  const wrapper = async (value: T, phase: ValidationPhase) => run(value, phase);
+
+  useEffect(() => {
+    const inner = sugar as unknown as SugarInner<T>;
+    inner.addValidator(wrapper);
+
+    const handleChange = async () => {
+      const result = await sugar.get();
+      if (result.result === 'success') {
+        await run(result.value, 'input');
+      }
+    };
+    const handleBlur = async () => {
+      const result = await sugar.get();
+      if (result.result === 'success') {
+        await run(result.value, 'blur');
+      }
+    };
+    sugar.addEventListener('change', handleChange);
+    sugar.addEventListener('blur', handleBlur);
+
+    return () => {
+      inner.removeValidator(wrapper);
+      sugar.removeEventListener('change', handleChange);
+      sugar.removeEventListener('blur', handleBlur);
+    };
+  }, [sugar]);
+
+  return validations;
+}

--- a/tests/core-unittest/src/useValidation.spec.tsx
+++ b/tests/core-unittest/src/useValidation.spec.tsx
@@ -1,0 +1,47 @@
+import { TextInput, useForm } from '@sugarform/core';
+import { render, renderHook, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { expect, test } from 'vitest';
+import { describeWithStrict } from '../util/describeWithStrict';
+
+describeWithStrict('Sugar#useValidation', () => {
+  test('validation triggered on blur', async () => {
+    const { result: sugar } = renderHook(() => useForm<string>({ template: '' }));
+    const { result: validations } = renderHook(() =>
+      sugar.current.useValidation<string>((value, fail) => {
+        if (value === '') fail('required', 'blur');
+      })
+    );
+
+    render(<TextInput sugar={sugar.current} />);
+
+    expect(validations.current).toStrictEqual([]);
+
+    await userEvent.click(screen.getByRole('textbox'));
+    await userEvent.tab();
+
+    expect(validations.current).toStrictEqual(['required']);
+  });
+
+  test('get(true) returns validation_fault', async () => {
+    const { result: sugar } = renderHook(() => useForm<string>({ template: '' }));
+    renderHook(() =>
+      sugar.current.useValidation<string>((value, fail) => {
+        if (value === '') fail('required', 'blur');
+      })
+    );
+    render(<TextInput sugar={sugar.current} />);
+
+    await userEvent.click(screen.getByRole('textbox'));
+    await userEvent.tab();
+
+    await expect(sugar.current.get(true)).resolves.toStrictEqual({
+      result: 'validation_fault',
+    });
+
+    await expect(sugar.current.get()).resolves.toStrictEqual({
+      result: 'success',
+      value: '',
+    });
+  });
+});

--- a/tests/core-unittest/src/useValidation.spec.tsx
+++ b/tests/core-unittest/src/useValidation.spec.tsx
@@ -5,7 +5,7 @@ import { expect, test } from 'vitest';
 import { describeWithStrict } from '../util/describeWithStrict';
 
 describeWithStrict('Sugar#useValidation', () => {
-  test('validation triggered on blur', async () => {
+  test('validation triggered on blur until success', async () => {
     const { result: sugar } = renderHook(() => useForm<string>({ template: '' }));
     const { result: validations } = renderHook(() =>
       sugar.current.useValidation<string>((value, fail) => {
@@ -21,9 +21,14 @@ describeWithStrict('Sugar#useValidation', () => {
     await userEvent.tab();
 
     expect(validations.current).toStrictEqual(['required']);
+
+    await userEvent.type(screen.getByRole('textbox'), 'a');
+    await userEvent.tab();
+
+    expect(validations.current).toStrictEqual([]);
   });
 
-  test('get(true) returns validation_fault', async () => {
+  test('get(true) returns validation_fault until valid', async () => {
     const { result: sugar } = renderHook(() => useForm<string>({ template: '' }));
     renderHook(() =>
       sugar.current.useValidation<string>((value, fail) => {
@@ -39,9 +44,62 @@ describeWithStrict('Sugar#useValidation', () => {
       result: 'validation_fault',
     });
 
+    await userEvent.type(screen.getByRole('textbox'), 'b');
+    await userEvent.tab();
+
+    await expect(sugar.current.get(true)).resolves.toStrictEqual({
+      result: 'success',
+      value: 'b',
+    });
+
     await expect(sugar.current.get()).resolves.toStrictEqual({
       result: 'success',
-      value: '',
+      value: 'b',
+    });
+  });
+
+  test('age must be at least 18', async () => {
+    const { result: sugar } = renderHook(() => useForm<string>({ template: '' }));
+    renderHook(() =>
+      sugar.current.useValidation<string>((value, fail) => {
+        const date = new Date(value);
+        if (Number.isNaN(date.getTime())) {
+          fail('invalid', 'blur');
+          return;
+        }
+        const now = new Date();
+        let age = now.getFullYear() - date.getFullYear();
+        const m = now.getMonth() - date.getMonth();
+        if (m < 0 || (m === 0 && now.getDate() < date.getDate())) {
+          age--;
+        }
+        if (age < 18) {
+          fail('underage', 'submit');
+        }
+      })
+    );
+    render(<TextInput sugar={sugar.current} />);
+    const input = screen.getByRole('textbox');
+
+    const fmt = (d: Date) => d.toISOString().slice(0, 10);
+    const now = new Date();
+    const underage = new Date(now.getFullYear() - 17, now.getMonth(), now.getDate());
+    const adult = new Date(now.getFullYear() - 18, now.getMonth(), now.getDate() - 1);
+
+    await userEvent.type(input, fmt(underage));
+    await userEvent.tab();
+
+    await expect(sugar.current.get(true)).resolves.toStrictEqual({
+      result: 'validation_fault',
+    });
+
+    await userEvent.clear(input);
+    await userEvent.type(input, fmt(adult));
+    await userEvent.tab();
+
+    await expect(sugar.current.get(true)).resolves.toStrictEqual({
+      result: 'success',
+      value: fmt(adult),
     });
   });
 });

--- a/tests/core-unittest/src/useValidation.spec.tsx
+++ b/tests/core-unittest/src/useValidation.spec.tsx
@@ -6,7 +6,9 @@ import { describeWithStrict } from '../util/describeWithStrict';
 
 describeWithStrict('Sugar#useValidation', () => {
   test('validation triggered on blur until success', async () => {
-    const { result: sugar } = renderHook(() => useForm<string>({ template: '' }));
+    const { result: sugar } = renderHook(() =>
+      useForm<string>({ template: '' })
+    );
     const { result: validations } = renderHook(() =>
       sugar.current.useValidation<string>((value, fail) => {
         if (value === '') fail('required', 'blur');
@@ -29,7 +31,9 @@ describeWithStrict('Sugar#useValidation', () => {
   });
 
   test('get(true) returns validation_fault until valid', async () => {
-    const { result: sugar } = renderHook(() => useForm<string>({ template: '' }));
+    const { result: sugar } = renderHook(() =>
+      useForm<string>({ template: '' })
+    );
     renderHook(() =>
       sugar.current.useValidation<string>((value, fail) => {
         if (value === '') fail('required', 'blur');
@@ -59,7 +63,9 @@ describeWithStrict('Sugar#useValidation', () => {
   });
 
   test('age must be at least 18', async () => {
-    const { result: sugar } = renderHook(() => useForm<string>({ template: '' }));
+    const { result: sugar } = renderHook(() =>
+      useForm<string>({ template: '' })
+    );
     renderHook(() =>
       sugar.current.useValidation<string>((value, fail) => {
         const date = new Date(value);
@@ -83,8 +89,16 @@ describeWithStrict('Sugar#useValidation', () => {
 
     const fmt = (d: Date) => d.toISOString().slice(0, 10);
     const now = new Date();
-    const underage = new Date(now.getFullYear() - 17, now.getMonth(), now.getDate());
-    const adult = new Date(now.getFullYear() - 18, now.getMonth(), now.getDate() - 1);
+    const underage = new Date(
+      now.getFullYear() - 17,
+      now.getMonth(),
+      now.getDate()
+    );
+    const adult = new Date(
+      now.getFullYear() - 18,
+      now.getMonth(),
+      now.getDate() - 1
+    );
 
     await userEvent.type(input, fmt(underage));
     await userEvent.tab();


### PR DESCRIPTION
- close #15 

## Summary
- implement `useValidation` hook with phase-aware validation
- expose `ValidationPhase` type
- support validators in `SugarInner`
- add tests for validation behavior

## Testing
- `pnpm exec vitest run`

------
https://chatgpt.com/codex/tasks/task_e_6847027b0dec8323a63709203a8cec60