### PR TITLE
feat(core): Add `Sugar#useValidation` hook

### DIFF
--- a/packages/core/src/lib.ts
+++ b/packages/core/src/lib.ts
@@ -1,4 +1,4 @@
 export { useForm } from './form';
 export { TextInput } from './components/textInput';
 export { NumberInput } from './components/numberInput';
-export type { Sugar } from './sugar/types';
+export type { Sugar, ValidationPhase } from './sugar/types';

--- a/packages/core/src/sugar/types.ts
+++ b/packages/core/src/sugar/types.ts
@@ -44,6 +44,12 @@ type SugarType<T extends SugarValue> = {
   ready: (getter: SugarGetter<T>, setter: SugarSetter<T>) => Promise<void>;
   destroy: () => void;
   useObject: SugarUseObject<T>;
+  useValidation: <V>(
+    validator: (
+      value: T,
+      fail: (reason: V, phase?: ValidationPhase) => void | Promise<void>
+    ) => void | Promise<void>
+  ) => V[];
   addEventListener: <K extends keyof SugarEvent<T>>(
     type: K,
     listener: CustomEventListener<SugarEvent<T>[K]>
@@ -72,3 +78,12 @@ export type SugarEvent<_T extends SugarValue> = {
   change: undefined;
   blur: undefined;
 };
+
+export type ValidationPhase = 'input' | 'blur' | 'submit';
+
+export type SugarUseValidation<T extends SugarValue, V> = (
+  validator: (
+    value: T,
+    fail: (reason: V, phase?: ValidationPhase) => void | Promise<void>
+  ) => void | Promise<void>
+) => V[];

--- a/packages/core/src/sugar/useValidation.ts
+++ b/packages/core/src/sugar/useValidation.ts
@@ -1,0 +1,71 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { Sugar } from './types';
+import type { ValidationPhase } from './types';
+import { SugarInner } from '.';
+
+const phaseWeight: Record<ValidationPhase, number> = {
+  input: 0,
+  blur: 1,
+  submit: 2,
+};
+
+export function useValidation<T, V>(
+  sugar: Sugar<T>,
+  validator: (
+    value: T,
+    fail: (reason: V, phase?: ValidationPhase) => void | Promise<void>
+  ) => void | Promise<void>
+): V[] {
+  const validatorRef = useRef(validator);
+  validatorRef.current = validator;
+
+  const [validations, setValidations] = useState<V[]>([]);
+
+  const run = useCallback(
+    async (value: T, phase: ValidationPhase): Promise<boolean> => {
+      const fails: V[] = [];
+      const fail = (v: V, p: ValidationPhase = 'submit') => {
+        if (phaseWeight[phase] >= phaseWeight[p]) {
+          fails.push(v);
+        }
+      };
+      await validatorRef.current(value, fail);
+      setValidations(fails);
+      return fails.length === 0;
+    },
+    []
+  );
+
+  const wrapper = useCallback(
+    async (value: T, phase: ValidationPhase) => run(value, phase),
+    [run]
+  );
+
+  useEffect(() => {
+    const inner = sugar as unknown as SugarInner<T>;
+    inner.addValidator(wrapper);
+
+    const handleChange = async () => {
+      const result = await sugar.get();
+      if (result.result === 'success') {
+        await run(result.value, 'input');
+      }
+    };
+    const handleBlur = async () => {
+      const result = await sugar.get();
+      if (result.result === 'success') {
+        await run(result.value, 'blur');
+      }
+    };
+    sugar.addEventListener('change', handleChange);
+    sugar.addEventListener('blur', handleBlur);
+
+    return () => {
+      inner.removeValidator(wrapper);
+      sugar.removeEventListener('change', handleChange);
+      sugar.removeEventListener('blur', handleBlur);
+    };
+  }, [sugar, run, wrapper]);
+
+  return validations;
+}

--- a/tests/core-unittest/src/useValidation.spec.tsx
+++ b/tests/core-unittest/src/useValidation.spec.tsx
@@ -1,0 +1,119 @@
+import { TextInput, useForm } from '@sugarform/core';
+import { render, renderHook, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { expect, test } from 'vitest';
+import { describeWithStrict } from '../util/describeWithStrict';
+
+describeWithStrict('Sugar#useValidation', () => {
+  test('validation triggered on blur until success', async () => {
+    const { result: sugar } = renderHook(() =>
+      useForm<string>({ template: '' })
+    );
+    const { result: validations } = renderHook(() =>
+      sugar.current.useValidation<string>((value, fail) => {
+        if (value === '') fail('required', 'blur');
+      })
+    );
+
+    render(<TextInput sugar={sugar.current} />);
+
+    expect(validations.current).toStrictEqual([]);
+
+    await userEvent.click(screen.getByRole('textbox'));
+    await userEvent.tab();
+
+    expect(validations.current).toStrictEqual(['required']);
+
+    await userEvent.type(screen.getByRole('textbox'), 'a');
+    await userEvent.tab();
+
+    expect(validations.current).toStrictEqual([]);
+  });
+
+  test('get(true) returns validation_fault until valid', async () => {
+    const { result: sugar } = renderHook(() =>
+      useForm<string>({ template: '' })
+    );
+    renderHook(() =>
+      sugar.current.useValidation<string>((value, fail) => {
+        if (value === '') fail('required', 'blur');
+      })
+    );
+    render(<TextInput sugar={sugar.current} />);
+
+    await userEvent.click(screen.getByRole('textbox'));
+    await userEvent.tab();
+
+    await expect(sugar.current.get(true)).resolves.toStrictEqual({
+      result: 'validation_fault',
+    });
+
+    await userEvent.type(screen.getByRole('textbox'), 'b');
+    await userEvent.tab();
+
+    await expect(sugar.current.get(true)).resolves.toStrictEqual({
+      result: 'success',
+      value: 'b',
+    });
+
+    await expect(sugar.current.get()).resolves.toStrictEqual({
+      result: 'success',
+      value: 'b',
+    });
+  });
+
+  test('age must be at least 18', async () => {
+    const { result: sugar } = renderHook(() =>
+      useForm<string>({ template: '' })
+    );
+    renderHook(() =>
+      sugar.current.useValidation<string>((value, fail) => {
+        const date = new Date(value);
+        if (Number.isNaN(date.getTime())) {
+          fail('invalid', 'blur');
+          return;
+        }
+        const now = new Date();
+        let age = now.getFullYear() - date.getFullYear();
+        const m = now.getMonth() - date.getMonth();
+        if (m < 0 || (m === 0 && now.getDate() < date.getDate())) {
+          age--;
+        }
+        if (age < 18) {
+          fail('underage', 'submit');
+        }
+      })
+    );
+    render(<TextInput sugar={sugar.current} />);
+    const input = screen.getByRole('textbox');
+
+    const fmt = (d: Date) => d.toISOString().slice(0, 10);
+    const now = new Date();
+    const underage = new Date(
+      now.getFullYear() - 17,
+      now.getMonth(),
+      now.getDate()
+    );
+    const adult = new Date(
+      now.getFullYear() - 18,
+      now.getMonth(),
+      now.getDate() - 1
+    );
+
+    await userEvent.type(input, fmt(underage));
+    await userEvent.tab();
+
+    await expect(sugar.current.get(true)).resolves.toStrictEqual({
+      result: 'validation_fault',
+    });
+
+    await userEvent.clear(input);
+    await userEvent.type(input, fmt(adult));
+    await userEvent.tab();
+
+    await expect(sugar.current.get(true)).resolves.toStrictEqual({
+      result: 'success',
+      value: fmt(adult),
+    });
+  });
+});


### PR DESCRIPTION
- close #15 
## Summary
- implement `useValidation` hook with phase-aware validation
- expose `ValidationPhase` type for consumers
- support validators in `SugarInner`
- add tests for validation behavior
- expand validation tests with success cases and age check
- format source files
- fix lint and typecheck issues with validation hook
- unify `useValidation` hook naming with `useObject`

## Testing
- `pnpm exec vitest run`
- `pnpm lint`
- `pnpm typecheck`


------
https://chatgpt.com/codex/tasks/task_e_6847027b0dec8323a63709203a8cec60