### PR TITLE
feat(core): add validation hook with staged triggers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,4 +22,4 @@ still show the attempt and mention the failure in your PR message.
 - When escaping the TypeScript type system (e.g. using `!` or `as unknown as`),
   explain why it is safe on the line immediately above the code in question.
 
-- Include `- close #15` in PR descriptions implementing issue 15.
+- Include `- close #<issue number>` in PR descriptions when a PR closes an issue.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,3 +21,5 @@ still show the attempt and mention the failure in your PR message.
   immediately before the disabling comment.
 - When escaping the TypeScript type system (e.g. using `!` or `as unknown as`),
   explain why it is safe on the line immediately above the code in question.
+
+- Include `- close #15` in PR descriptions implementing issue 15.

--- a/packages/core/build.ts
+++ b/packages/core/build.ts
@@ -110,6 +110,11 @@ async function pipeline(format: 'esm' | 'cjs') {
       },
       target: 'es2017',
       loose: false,
+      transform: {
+        react: {
+          runtime: 'automatic',
+        },
+      },
     },
   });
 

--- a/packages/core/src/components/numberInput.tsx
+++ b/packages/core/src/components/numberInput.tsx
@@ -10,7 +10,7 @@ export function NumberInput({
   useEffect(() => {
     if (ref.current) {
       sugar.ready(
-        (_submit) => {
+        (_stage) => {
           if (!ref.current) {
             return Promise.resolve({ result: 'unavailable' });
           }

--- a/packages/core/src/components/numberInput.tsx
+++ b/packages/core/src/components/numberInput.tsx
@@ -10,7 +10,7 @@ export function NumberInput({
   useEffect(() => {
     if (ref.current) {
       sugar.ready(
-        (_stage) => {
+        (_submit) => {
           if (!ref.current) {
             return Promise.resolve({ result: 'unavailable' });
           }

--- a/packages/core/src/components/numberInput.tsx
+++ b/packages/core/src/components/numberInput.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from 'react';
+import { useEffect, useRef } from 'react';
 import { Sugar } from '../lib';
 
 export function NumberInput({

--- a/packages/core/src/components/numberInput.tsx
+++ b/packages/core/src/components/numberInput.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react';
+import React, { useEffect, useRef } from 'react';
 import { Sugar } from '../lib';
 
 export function NumberInput({

--- a/packages/core/src/components/numberInput.tsx
+++ b/packages/core/src/components/numberInput.tsx
@@ -10,7 +10,7 @@ export function NumberInput({
   useEffect(() => {
     if (ref.current) {
       sugar.ready(
-        () => {
+        (_submit) => {
           if (!ref.current) {
             return Promise.resolve({ result: 'unavailable' });
           }

--- a/packages/core/src/components/textInput.tsx
+++ b/packages/core/src/components/textInput.tsx
@@ -10,7 +10,7 @@ export function TextInput({
   useEffect(() => {
     if (ref.current) {
       sugar.ready(
-        (_stage) => {
+        (_submit) => {
           if (!ref.current) {
             return Promise.resolve({ result: 'unavailable' });
           }

--- a/packages/core/src/components/textInput.tsx
+++ b/packages/core/src/components/textInput.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react';
+import React, { useEffect, useRef } from 'react';
 import { Sugar } from '../lib';
 
 export function TextInput({

--- a/packages/core/src/components/textInput.tsx
+++ b/packages/core/src/components/textInput.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from 'react';
+import { useEffect, useRef } from 'react';
 import { Sugar } from '../lib';
 
 export function TextInput({

--- a/packages/core/src/components/textInput.tsx
+++ b/packages/core/src/components/textInput.tsx
@@ -10,7 +10,7 @@ export function TextInput({
   useEffect(() => {
     if (ref.current) {
       sugar.ready(
-        (_submit) => {
+        (_stage) => {
           if (!ref.current) {
             return Promise.resolve({ result: 'unavailable' });
           }

--- a/packages/core/src/components/textInput.tsx
+++ b/packages/core/src/components/textInput.tsx
@@ -10,7 +10,7 @@ export function TextInput({
   useEffect(() => {
     if (ref.current) {
       sugar.ready(
-        () => {
+        (_submit) => {
           if (!ref.current) {
             return Promise.resolve({ result: 'unavailable' });
           }

--- a/packages/core/src/sugar/index.ts
+++ b/packages/core/src/sugar/index.ts
@@ -94,18 +94,21 @@ export class SugarInner<T extends SugarValue> {
     return results.every((r) => r);
   }
 
-  async getInternal(stage: ValidationStage = 'input'): Promise<SugarGetResult<T>> {
+  async getInternal(
+    stage: ValidationStage = 'input'
+  ): Promise<SugarGetResult<T>> {
     switch (this.status.status) {
       case 'unavailable':
         return { result: 'unavailable' };
       case 'unready':
         return this.status.getPromise;
       case 'ready':
-        return this.status.getter(stage);
+        return this.status.getter(stage === 'submit');
     }
   }
 
-  async get(stage: ValidationStage = 'input'): Promise<SugarGetResult<T>> {
+  async get(submit = false): Promise<SugarGetResult<T>> {
+    const stage: ValidationStage = submit ? 'submit' : 'input';
     const result = await this.getInternal(stage);
     if (result.result !== 'success') {
       return result;
@@ -167,7 +170,7 @@ export class SugarInner<T extends SugarValue> {
       status.resolveSetPromise(
         await setter(status.recentValue ?? this.template)
       );
-      status.resolveGetPromise(await getter('input'));
+      status.resolveGetPromise(await getter(false));
     }
 
     this.status = {

--- a/packages/core/src/sugar/types.ts
+++ b/packages/core/src/sugar/types.ts
@@ -27,7 +27,7 @@ export type ValidationStage = 'input' | 'blur' | 'submit';
 export type FailFn<V> = (value: V, stage?: ValidationStage) => void;
 
 export type SugarGetter<T extends SugarValue> = (
-  stage?: ValidationStage
+  submit?: boolean
 ) => Promise<SugarGetResult<T>>;
 export type SugarSetter<T extends SugarValue> = (
   value: T

--- a/packages/core/src/sugar/types.ts
+++ b/packages/core/src/sugar/types.ts
@@ -21,9 +21,14 @@ export type SugarSetResult<_T extends SugarValue> =
       result: 'unavailable';
     };
 
-export type SugarGetter<T extends SugarValue> = () => Promise<
-  SugarGetResult<T>
->;
+import type { DependencyList } from 'react';
+
+export type ValidationStage = 'input' | 'blur' | 'submit';
+export type FailFn<V> = (value: V, stage?: ValidationStage) => void;
+
+export type SugarGetter<T extends SugarValue> = (
+  submit?: boolean
+) => Promise<SugarGetResult<T>>;
 export type SugarSetter<T extends SugarValue> = (
   value: T
 ) => Promise<SugarSetResult<T>>;
@@ -38,12 +43,18 @@ export type SugarUseObject<T extends SugarValue> = T extends SugarValueObject
   ? () => SugarUseObjectResult<T>
   : never;
 
+export type SugarUseValidation<T extends SugarValue> = <V>(
+  validator: (value: T, fail: FailFn<V>) => void | Promise<void>,
+  deps?: DependencyList
+) => V[];
+
 type SugarType<T extends SugarValue> = {
   get: SugarGetter<T>;
   set: SugarSetter<T>;
   ready: (getter: SugarGetter<T>, setter: SugarSetter<T>) => Promise<void>;
   destroy: () => void;
   useObject: SugarUseObject<T>;
+  useValidation: SugarUseValidation<T>;
   addEventListener: <K extends keyof SugarEvent<T>>(
     type: K,
     listener: CustomEventListener<SugarEvent<T>[K]>
@@ -71,4 +82,5 @@ export type CustomEventListener<T> = (evt: CustomEvent<T>) => void;
 export type SugarEvent<_T extends SugarValue> = {
   change: undefined;
   blur: undefined;
+  submit: undefined;
 };

--- a/packages/core/src/sugar/types.ts
+++ b/packages/core/src/sugar/types.ts
@@ -27,7 +27,7 @@ export type ValidationStage = 'input' | 'blur' | 'submit';
 export type FailFn<V> = (value: V, stage?: ValidationStage) => void;
 
 export type SugarGetter<T extends SugarValue> = (
-  submit?: boolean
+  stage?: ValidationStage
 ) => Promise<SugarGetResult<T>>;
 export type SugarSetter<T extends SugarValue> = (
   value: T

--- a/packages/core/src/sugar/useObject.ts
+++ b/packages/core/src/sugar/useObject.ts
@@ -26,17 +26,14 @@ export function useObject<T extends SugarValueObject>(
     // イベントを接続
     const dispatchChange = () => sugar.dispatchEvent('change');
     const dispatchBlur = () => sugar.dispatchEvent('blur');
-    const dispatchSubmit = () => sugar.dispatchEvent('submit');
-
     sugars.current!.values().forEach((sugar) => {
       //     ^^^^^^^^ 上でsugarsを初期化しているので、sugars.currentはundefinedではない
       sugar.addEventListener('change', dispatchChange);
       sugar.addEventListener('blur', dispatchBlur);
-      sugar.addEventListener('submit', dispatchSubmit);
     });
 
     sugar.ready(
-      async (submit) => {
+      async (stage) => {
         if (!matchSugars(sugar, sugars.current)) {
           console.error(
             'The keys of the sugar template and map do not match. This is probably a problem on the SugarForm side, so please report it.'
@@ -50,7 +47,7 @@ export function useObject<T extends SugarValueObject>(
         // すべてのsugarのgetterを実行する。
         const values: [string, SugarGetResult<unknown>][] = await Promise.all(
           [...sugars.current.entries()].map(async ([key, value]) => {
-            const result = await value.get(submit);
+            const result = await value.get(stage);
             return [key, result];
           })
         );
@@ -127,7 +124,6 @@ export function useObject<T extends SugarValueObject>(
         sugars.current.values().forEach((sugar) => {
           sugar.removeEventListener('change', dispatchChange);
           sugar.removeEventListener('blur', dispatchBlur);
-          sugar.removeEventListener('submit', dispatchSubmit);
         });
       }
     };

--- a/packages/core/src/sugar/useObject.ts
+++ b/packages/core/src/sugar/useObject.ts
@@ -26,15 +26,17 @@ export function useObject<T extends SugarValueObject>(
     // イベントを接続
     const dispatchChange = () => sugar.dispatchEvent('change');
     const dispatchBlur = () => sugar.dispatchEvent('blur');
+    const dispatchSubmit = () => sugar.dispatchEvent('submit');
 
     sugars.current!.values().forEach((sugar) => {
       //     ^^^^^^^^ 上でsugarsを初期化しているので、sugars.currentはundefinedではない
       sugar.addEventListener('change', dispatchChange);
       sugar.addEventListener('blur', dispatchBlur);
+      sugar.addEventListener('submit', dispatchSubmit);
     });
 
     sugar.ready(
-      async () => {
+      async (submit) => {
         if (!matchSugars(sugar, sugars.current)) {
           console.error(
             'The keys of the sugar template and map do not match. This is probably a problem on the SugarForm side, so please report it.'
@@ -48,7 +50,7 @@ export function useObject<T extends SugarValueObject>(
         // すべてのsugarのgetterを実行する。
         const values: [string, SugarGetResult<unknown>][] = await Promise.all(
           [...sugars.current.entries()].map(async ([key, value]) => {
-            const result = await value.get();
+            const result = await value.get(submit);
             return [key, result];
           })
         );
@@ -125,6 +127,7 @@ export function useObject<T extends SugarValueObject>(
         sugars.current.values().forEach((sugar) => {
           sugar.removeEventListener('change', dispatchChange);
           sugar.removeEventListener('blur', dispatchBlur);
+          sugar.removeEventListener('submit', dispatchSubmit);
         });
       }
     };

--- a/packages/core/src/sugar/useObject.ts
+++ b/packages/core/src/sugar/useObject.ts
@@ -33,7 +33,7 @@ export function useObject<T extends SugarValueObject>(
     });
 
     sugar.ready(
-      async (stage) => {
+      async (submit) => {
         if (!matchSugars(sugar, sugars.current)) {
           console.error(
             'The keys of the sugar template and map do not match. This is probably a problem on the SugarForm side, so please report it.'
@@ -47,7 +47,7 @@ export function useObject<T extends SugarValueObject>(
         // すべてのsugarのgetterを実行する。
         const values: [string, SugarGetResult<unknown>][] = await Promise.all(
           [...sugars.current.entries()].map(async ([key, value]) => {
-            const result = await value.get(stage);
+            const result = await value.get(submit);
             return [key, result];
           })
         );

--- a/packages/core/src/sugar/useValidation.ts
+++ b/packages/core/src/sugar/useValidation.ts
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useState } from 'react';
+import { SugarInner } from '.';
 import { Sugar, SugarValue, ValidationStage, FailFn } from './types';
 
 export function useValidation<T extends SugarValue, V>(
@@ -8,13 +9,8 @@ export function useValidation<T extends SugarValue, V>(
 ): V[] {
   const [errors, setErrors] = useState<V[]>([]);
 
-  const run = useCallback(
-    async (stage: ValidationStage) => {
-      const result = await sugar.get();
-      if (result.result !== 'success') {
-        setErrors([]);
-        return;
-      }
+  const validatorWrapper = useCallback(
+    async (stage: ValidationStage, value: T) => {
       const fails: V[] = [];
       const fail: FailFn<V> = (v, s = 'submit') => {
         const order = { input: 0, blur: 1, submit: 2 } as const;
@@ -22,25 +18,46 @@ export function useValidation<T extends SugarValue, V>(
           fails.push(v);
         }
       };
-      await validator(result.value, fail);
+      await validator(value, fail);
       setErrors(fails);
+      return fails.length === 0;
     },
-    // Spread deps is necessary to allow user-defined dependency array
     // eslint-disable-next-line react-hooks/exhaustive-deps -- Spread is required to include user deps
-    [sugar, validator, ...deps]
+    [validator, ...deps]
+  );
+
+  useEffect(() => {
+    // Casting is safe because useValidation is always used with SugarInner
+    // instances produced by useForm or useObject
+    (sugar as unknown as SugarInner<T>).registerValidator(validatorWrapper);
+    return () => {
+      // same reasoning as above
+      (sugar as unknown as SugarInner<T>).unregisterValidator(validatorWrapper);
+    };
+  }, [sugar, validatorWrapper]);
+
+  const run = useCallback(
+    async (stage: ValidationStage) => {
+      // Casting is safe because sugar is created via SugarInner
+      const inner = sugar as unknown as SugarInner<T>;
+      const result = await inner.getInternal(stage);
+      if (result.result !== 'success') {
+        setErrors([]);
+        return;
+      }
+      await validatorWrapper(stage, result.value);
+    },
+    [sugar, validatorWrapper]
   );
 
   useEffect(() => {
     const onChange = () => run('input');
     const onBlur = () => run('blur');
-    const onSubmit = () => run('submit');
     sugar.addEventListener('change', onChange);
     sugar.addEventListener('blur', onBlur);
-    sugar.addEventListener('submit', onSubmit);
     return () => {
       sugar.removeEventListener('change', onChange);
       sugar.removeEventListener('blur', onBlur);
-      sugar.removeEventListener('submit', onSubmit);
     };
   }, [run, sugar]);
 

--- a/packages/core/src/sugar/useValidation.ts
+++ b/packages/core/src/sugar/useValidation.ts
@@ -1,0 +1,53 @@
+import { useCallback, useEffect, useState } from 'react';
+import { Sugar, SugarValue, ValidationStage, FailFn } from './types';
+
+export function useValidation<T extends SugarValue, V>(
+  sugar: Sugar<T>,
+  validator: (value: T, fail: FailFn<V>) => void | Promise<void>,
+  deps: React.DependencyList = []
+): V[] {
+  const [errors, setErrors] = useState<V[]>([]);
+
+  const run = useCallback(
+    async (stage: ValidationStage) => {
+      const result = await sugar.get();
+      if (result.result !== 'success') {
+        setErrors([]);
+        return;
+      }
+      const fails: V[] = [];
+      const fail: FailFn<V> = (v, s = 'submit') => {
+        const order = { input: 0, blur: 1, submit: 2 } as const;
+        if (order[stage] >= order[s]) {
+          fails.push(v);
+        }
+      };
+      await validator(result.value, fail);
+      setErrors(fails);
+    },
+    // Spread deps is necessary to allow user-defined dependency array
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- Spread is required to include user deps
+    [sugar, validator, ...deps]
+  );
+
+  useEffect(() => {
+    const onChange = () => run('input');
+    const onBlur = () => run('blur');
+    const onSubmit = () => run('submit');
+    sugar.addEventListener('change', onChange);
+    sugar.addEventListener('blur', onBlur);
+    sugar.addEventListener('submit', onSubmit);
+    return () => {
+      sugar.removeEventListener('change', onChange);
+      sugar.removeEventListener('blur', onBlur);
+      sugar.removeEventListener('submit', onSubmit);
+    };
+  }, [run, sugar]);
+
+  // run once on mount
+  useEffect(() => {
+    run('input');
+  }, [run]);
+
+  return errors;
+}

--- a/tests/core-unittest/src/birthdayInput.spec.tsx
+++ b/tests/core-unittest/src/birthdayInput.spec.tsx
@@ -1,0 +1,129 @@
+import { NumberInput, useForm, type Sugar } from '@sugarform/core';
+import {
+  act,
+  render,
+  renderHook,
+  screen,
+  waitFor,
+} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { expect, test } from 'vitest';
+import { describeWithStrict } from '../util/describeWithStrict';
+
+type Birthday = {
+  year: number;
+  month: number;
+  day: number;
+};
+
+type ValidationResult =
+  | { type: 'missed'; name: ('year' | 'month' | 'day')[] }
+  | { type: 'young' };
+
+function toMessage(v: ValidationResult): string {
+  switch (v.type) {
+    case 'missed':
+      return `${v.name.join(', ')} missing`;
+    case 'young':
+      return 'too young';
+  }
+}
+
+const validator = async (
+  value: Birthday,
+  fail: (v: ValidationResult, s?: string) => void
+) => {
+  const complete =
+    !Number.isNaN(value.year) &&
+    !Number.isNaN(value.month) &&
+    !Number.isNaN(value.day);
+  if (!complete) {
+    const missed: ('year' | 'month' | 'day')[] = [];
+    if (Number.isNaN(value.year)) missed.push('year');
+    if (Number.isNaN(value.month)) missed.push('month');
+    if (Number.isNaN(value.day)) missed.push('day');
+    fail({ type: 'missed', name: missed }, 'submit');
+    return;
+  }
+  const birthday = new Date(value.year, value.month - 1, value.day);
+  const today = new Date(2025, 0, 1);
+  const age = today.getFullYear() - birthday.getFullYear();
+  const passed =
+    today.getMonth() > birthday.getMonth() ||
+    (today.getMonth() === birthday.getMonth() &&
+      today.getDate() >= birthday.getDate());
+  if (age < 20 || (age === 20 && !passed)) {
+    fail({ type: 'young' }, 'blur');
+  }
+};
+
+function BirthdayInput({ sugar }: { sugar: Sugar<Birthday> }) {
+  const { fields } = sugar.useObject();
+  const errors = sugar.useValidation(validator);
+
+  return (
+    <div>
+      <NumberInput sugar={fields.year} placeholder="y" />
+      <NumberInput sugar={fields.month} placeholder="m" />
+      <NumberInput sugar={fields.day} placeholder="d" />
+      {errors.map((e, i) => (
+        <div key={i} role="alert">
+          {toMessage(e)}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+describeWithStrict('BirthdayInput', () => {
+  test('shows missing fields on submit', async () => {
+    const { result } = renderHook(() =>
+      useForm<Birthday>({ template: { year: NaN, month: NaN, day: NaN } })
+    );
+    render(<BirthdayInput sugar={result.current} />);
+    await act(async () => {});
+
+    expect(screen.queryAllByRole('alert')).toHaveLength(0);
+
+    await act(async () => {
+      await result.current.get(true);
+    });
+
+    await waitFor(() => {
+      const alerts = screen.getAllByRole('alert');
+      expect(alerts).toHaveLength(1);
+      expect(alerts[0].textContent).toBe('year, month, day missing');
+    });
+  });
+
+  test('shows age error on blur and clears after correction', async () => {
+    const { result } = renderHook(() =>
+      useForm<Birthday>({ template: { year: NaN, month: NaN, day: NaN } })
+    );
+    render(<BirthdayInput sugar={result.current} />);
+    await act(async () => {});
+    const user = userEvent.setup();
+    const year = screen.getByPlaceholderText('y');
+    const month = screen.getByPlaceholderText('m');
+    const day = screen.getByPlaceholderText('d');
+
+    await user.type(year, '2010');
+    await user.type(month, '1');
+    await user.type(day, '1');
+    await user.tab();
+
+    await waitFor(() => {
+      const alerts = screen.getAllByRole('alert');
+      expect(alerts).toHaveLength(1);
+      expect(alerts[0].textContent).toBe('too young');
+    });
+
+    await user.clear(year);
+    await user.type(year, '2000');
+    await user.tab();
+
+    await waitFor(() => {
+      expect(screen.queryAllByRole('alert')).toHaveLength(0);
+    });
+  });
+});

--- a/tests/core-unittest/src/useValidation.spec.tsx
+++ b/tests/core-unittest/src/useValidation.spec.tsx
@@ -72,7 +72,7 @@ describeWithStrict('Sugar#useValidation', () => {
     expect(errors.current).toStrictEqual([]);
 
     await act(async () => {
-      await sugar.current.get('submit');
+      await sugar.current.get(true);
     });
     await waitFor(() =>
       expect(errors.current).toStrictEqual([
@@ -138,7 +138,7 @@ describeWithStrict('Sugar#useValidation', () => {
     expect(errB.current).toStrictEqual([]);
 
     await act(async () => {
-      await sugar.current.get('submit');
+      await sugar.current.get(true);
     });
 
     await waitFor(() => expect(errA.current).toStrictEqual([]));
@@ -162,7 +162,7 @@ describeWithStrict('Sugar#useValidation', () => {
 
     await act(async () => {});
 
-    await expect(sugar.current.get('submit')).resolves.toStrictEqual({
+    await expect(sugar.current.get(true)).resolves.toStrictEqual({
       result: 'validation_fault',
     });
   });

--- a/tests/core-unittest/src/useValidation.spec.tsx
+++ b/tests/core-unittest/src/useValidation.spec.tsx
@@ -1,4 +1,4 @@
-import { NumberInput, TextInput, useForm } from '@sugarform/core';
+import { TextInput, useForm } from '@sugarform/core';
 import {
   act,
   render,
@@ -10,92 +10,7 @@ import userEvent from '@testing-library/user-event';
 import { expect, test } from 'vitest';
 import { describeWithStrict } from '../util/describeWithStrict';
 
-type Birthday = {
-  year: number;
-  month: number;
-  day: number;
-};
-
 describeWithStrict('Sugar#useValidation', () => {
-  test('validator triggers by stage as in issue example', async () => {
-    const { result: sugar } = renderHook(() =>
-      useForm<Birthday>({ template: { year: NaN, month: NaN, day: NaN } })
-    );
-    const { result: object } = renderHook(() => sugar.current.useObject());
-
-    const validator = async (
-      value: Birthday,
-      fail: (v: unknown, s?: string) => void
-    ) => {
-      const complete =
-        !Number.isNaN(value.year) &&
-        !Number.isNaN(value.month) &&
-        !Number.isNaN(value.day);
-      if (!complete) {
-        const missed: ('year' | 'month' | 'day')[] = [];
-        if (Number.isNaN(value.year)) missed.push('year');
-        if (Number.isNaN(value.month)) missed.push('month');
-        if (Number.isNaN(value.day)) missed.push('day');
-        fail({ type: 'missed', name: missed }, 'submit');
-        return;
-      }
-      const birthday = new Date(value.year, value.month - 1, value.day);
-      const today = new Date(2025, 0, 1);
-      const age = today.getFullYear() - birthday.getFullYear();
-      const passed =
-        today.getMonth() > birthday.getMonth() ||
-        (today.getMonth() === birthday.getMonth() &&
-          today.getDate() >= birthday.getDate());
-      if (age < 20 || (age === 20 && !passed)) {
-        fail({ type: 'young' }, 'blur');
-      }
-    };
-
-    const { result: errors } = renderHook(() =>
-      sugar.current.useValidation(validator)
-    );
-
-    render(
-      <>
-        <NumberInput sugar={object.current.fields.year} placeholder="y" />
-        <NumberInput sugar={object.current.fields.month} placeholder="m" />
-        <NumberInput sugar={object.current.fields.day} placeholder="d" />
-      </>
-    );
-    await act(async () => {});
-
-    const user = userEvent.setup();
-    const year = screen.getByPlaceholderText('y');
-    const month = screen.getByPlaceholderText('m');
-    const day = screen.getByPlaceholderText('d');
-
-    expect(errors.current).toStrictEqual([]);
-
-    await act(async () => {
-      await sugar.current.get(true);
-    });
-    await waitFor(() =>
-      expect(errors.current).toStrictEqual([
-        { type: 'missed', name: ['year', 'month', 'day'] },
-      ])
-    );
-
-    await user.type(year, '2010');
-    await user.type(month, '1');
-    await user.type(day, '1');
-    expect(errors.current).toStrictEqual([]);
-
-    await user.tab();
-    await waitFor(() =>
-      expect(errors.current).toStrictEqual([{ type: 'young' }])
-    );
-
-    await user.clear(year);
-    await user.type(year, '2000');
-    await user.tab();
-    await waitFor(() => expect(errors.current).toStrictEqual([]));
-  });
-
   test('submit events from get propagate to nested sugars', async () => {
     const { result: sugar } = renderHook(() =>
       useForm({ template: { a: '', b: '' } })

--- a/tests/core-unittest/src/useValidation.spec.tsx
+++ b/tests/core-unittest/src/useValidation.spec.tsx
@@ -1,0 +1,141 @@
+import { NumberInput, TextInput, useForm } from '@sugarform/core';
+import {
+  act,
+  render,
+  renderHook,
+  screen,
+  waitFor,
+} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { expect, test } from 'vitest';
+import { describeWithStrict } from '../util/describeWithStrict';
+
+type Birthday = {
+  year: number;
+  month: number;
+  day: number;
+};
+
+describeWithStrict('Sugar#useValidation', () => {
+  test('validator triggers by stage as in issue example', async () => {
+    const { result: sugar } = renderHook(() =>
+      useForm<Birthday>({ template: { year: NaN, month: NaN, day: NaN } })
+    );
+    const { result: object } = renderHook(() => sugar.current.useObject());
+
+    const validator = (
+      value: Birthday,
+      fail: (v: unknown, s?: string) => void
+    ) => {
+      const complete =
+        !Number.isNaN(value.year) &&
+        !Number.isNaN(value.month) &&
+        !Number.isNaN(value.day);
+      if (!complete) {
+        const missed: ('year' | 'month' | 'day')[] = [];
+        if (Number.isNaN(value.year)) missed.push('year');
+        if (Number.isNaN(value.month)) missed.push('month');
+        if (Number.isNaN(value.day)) missed.push('day');
+        fail({ type: 'missed', name: missed }, 'submit');
+        return;
+      }
+      const birthday = new Date(value.year, value.month - 1, value.day);
+      const today = new Date(2025, 0, 1);
+      const age = today.getFullYear() - birthday.getFullYear();
+      const passed =
+        today.getMonth() > birthday.getMonth() ||
+        (today.getMonth() === birthday.getMonth() &&
+          today.getDate() >= birthday.getDate());
+      if (age < 20 || (age === 20 && !passed)) {
+        fail({ type: 'young' }, 'blur');
+      }
+    };
+
+    const { result: errors } = renderHook(() =>
+      sugar.current.useValidation(validator)
+    );
+
+    render(
+      <>
+        <NumberInput sugar={object.current.fields.year} placeholder="y" />
+        <NumberInput sugar={object.current.fields.month} placeholder="m" />
+        <NumberInput sugar={object.current.fields.day} placeholder="d" />
+      </>
+    );
+    await act(async () => {});
+
+    const user = userEvent.setup();
+    const year = screen.getByPlaceholderText('y');
+    const month = screen.getByPlaceholderText('m');
+    const day = screen.getByPlaceholderText('d');
+
+    expect(errors.current).toStrictEqual([]);
+
+    await act(async () => {
+      await sugar.current.get(true);
+    });
+    await waitFor(() =>
+      expect(errors.current).toStrictEqual([
+        { type: 'missed', name: ['year', 'month', 'day'] },
+      ])
+    );
+
+    await user.type(year, '2010');
+    await user.type(month, '1');
+    await user.type(day, '1');
+    expect(errors.current).toStrictEqual([]);
+
+    await user.tab();
+    await waitFor(() =>
+      expect(errors.current).toStrictEqual([{ type: 'young' }])
+    );
+
+    await user.clear(year);
+    await user.type(year, '2000');
+    await user.tab();
+    await waitFor(() => expect(errors.current).toStrictEqual([]));
+  });
+
+  test('submit events from get propagate to nested sugars', async () => {
+    const { result: sugar } = renderHook(() =>
+      useForm({ template: { a: '', b: '' } })
+    );
+    const { result: obj } = renderHook(() => sugar.current.useObject());
+
+    const validateA = (v: string, fail: (err: string, s?: string) => void) => {
+      if (v === '') fail('required', 'submit');
+    };
+    const validateB = (v: string, fail: (err: string, s?: string) => void) => {
+      if (v === '') fail('required', 'submit');
+    };
+
+    const { result: errA } = renderHook(() =>
+      obj.current.fields.a.useValidation(validateA)
+    );
+    const { result: errB } = renderHook(() =>
+      obj.current.fields.b.useValidation(validateB)
+    );
+
+    render(
+      <>
+        <TextInput sugar={obj.current.fields.a} placeholder="a" />
+        <TextInput sugar={obj.current.fields.b} placeholder="b" />
+      </>
+    );
+    await act(async () => {});
+
+    const user = userEvent.setup();
+    const inputA = screen.getByPlaceholderText('a');
+    await user.type(inputA, 'filled');
+
+    expect(errA.current).toStrictEqual([]);
+    expect(errB.current).toStrictEqual([]);
+
+    await act(async () => {
+      await sugar.current.get(true);
+    });
+
+    await waitFor(() => expect(errA.current).toStrictEqual([]));
+    await waitFor(() => expect(errB.current).toStrictEqual(['required']));
+  });
+});

--- a/tests/sandbox/src/App.tsx
+++ b/tests/sandbox/src/App.tsx
@@ -3,6 +3,18 @@ import { useCallback } from 'react';
 import './App.css';
 import { useForm, TextInput, NumberInput, type Sugar } from '@sugarform/core';
 
+type Birthday = {
+  year: number;
+  month: number;
+  day: number;
+};
+
+type Person = {
+  firstName: string;
+  lastName: string;
+  birthday: Birthday;
+};
+
 type FormType = {
   person_a: Person;
   person_b: Person;
@@ -14,10 +26,12 @@ function App() {
       person_a: {
         firstName: '',
         lastName: '',
+        birthday: { year: NaN, month: NaN, day: NaN },
       },
       person_b: {
         firstName: '',
         lastName: '',
+        birthday: { year: NaN, month: NaN, day: NaN },
       },
     },
   });
@@ -41,15 +55,9 @@ function App() {
         get
       </button>
       <hr />
-      <BirthdayExample />
     </>
   );
 }
-
-type Person = {
-  firstName: string;
-  lastName: string;
-};
 
 function PersonInput({ sugar }: { sugar: Sugar<Person> }) {
   const { fields } = sugar.useObject();
@@ -64,24 +72,15 @@ function PersonInput({ sugar }: { sugar: Sugar<Person> }) {
         Last Name:
         <TextInput sugar={fields.lastName} />
       </label>
+      <BirthdayInput sugar={fields.birthday} />
     </div>
   );
 }
 
-type Birthday = {
-  year: number;
-  month: number;
-  day: number;
-};
+function BirthdayInput({ sugar }: { sugar: Sugar<Birthday> }) {
+  const { fields } = sugar.useObject();
 
-function BirthdayExample() {
-  const birthdaySugar = useForm<Birthday>({
-    template: { year: NaN, month: NaN, day: NaN },
-  });
-
-  const { fields } = birthdaySugar.useObject();
-
-  const errors = birthdaySugar.useValidation<string>(
+  const errors = sugar.useValidation<string>(
     useCallback((value, fail) => {
       const complete =
         !Number.isNaN(value.year) &&
@@ -111,7 +110,6 @@ function BirthdayExample() {
 
   return (
     <div>
-      <h2>Birthday</h2>
       <label>
         Year:
         <NumberInput sugar={fields.year} />
@@ -124,15 +122,6 @@ function BirthdayExample() {
         Day:
         <NumberInput sugar={fields.day} />
       </label>
-      <button
-        type="button"
-        onClick={async () => {
-          const result = await birthdaySugar.get(true);
-          console.log(result);
-        }}
-      >
-        get birthday
-      </button>
       {errors.map((e, i) => (
         <div key={i} className="error">
           {e}

--- a/tests/sandbox/src/App.tsx
+++ b/tests/sandbox/src/App.tsx
@@ -48,7 +48,7 @@ function App() {
       <button
         type="button"
         onClick={async () => {
-          const result = await sugar.get();
+          const result = await sugar.get('submit');
           console.log(result);
         }}
       >
@@ -81,7 +81,7 @@ function BirthdayInput({ sugar }: { sugar: Sugar<Birthday> }) {
   const { fields } = sugar.useObject();
 
   const errors = sugar.useValidation<string>(
-    useCallback((value, fail) => {
+    useCallback(async (value, fail) => {
       const complete =
         !Number.isNaN(value.year) &&
         !Number.isNaN(value.month) &&

--- a/tests/sandbox/src/App.tsx
+++ b/tests/sandbox/src/App.tsx
@@ -48,7 +48,7 @@ function App() {
       <button
         type="button"
         onClick={async () => {
-          const result = await sugar.get('submit');
+          const result = await sugar.get(true);
           console.log(result);
         }}
       >

--- a/tests/sandbox/src/App.tsx
+++ b/tests/sandbox/src/App.tsx
@@ -1,6 +1,7 @@
-import { useEffect, useRef } from 'react';
+import { useCallback } from 'react';
+// Demo showing how validation errors appear in real usage
 import './App.css';
-import { useForm, type Sugar } from '@sugarform/core';
+import { useForm, TextInput, NumberInput, type Sugar } from '@sugarform/core';
 
 type FormType = {
   person_a: Person;
@@ -39,6 +40,8 @@ function App() {
       >
         get
       </button>
+      <hr />
+      <BirthdayExample />
     </>
   );
 }
@@ -65,35 +68,76 @@ function PersonInput({ sugar }: { sugar: Sugar<Person> }) {
   );
 }
 
-function TextInput({ sugar }: { sugar: Sugar<string> }) {
-  const ref = useRef<HTMLInputElement>(null);
+type Birthday = {
+  year: number;
+  month: number;
+  day: number;
+};
 
-  useEffect(() => {
-    if (ref.current) {
-      sugar.ready(
-        () => {
-          if (!ref.current) {
-            return Promise.resolve({ result: 'unavailable' });
-          }
-          return Promise.resolve({
-            result: 'success',
-            value: ref.current.value,
-          });
-        },
-        (value) => {
-          if (!ref.current) {
-            return Promise.resolve({ result: 'unavailable' });
-          }
-          ref.current.value = value;
-          return Promise.resolve({ result: 'success' });
-        }
-      );
-    }
-  }, [sugar]);
+function BirthdayExample() {
+  const birthdaySugar = useForm<Birthday>({
+    template: { year: NaN, month: NaN, day: NaN },
+  });
+
+  const { fields } = birthdaySugar.useObject();
+
+  const errors = birthdaySugar.useValidation<string>(
+    useCallback((value, fail) => {
+      const complete =
+        !Number.isNaN(value.year) &&
+        !Number.isNaN(value.month) &&
+        !Number.isNaN(value.day);
+      if (!complete) {
+        const missed: string[] = [];
+        if (Number.isNaN(value.year)) missed.push('year');
+        if (Number.isNaN(value.month)) missed.push('month');
+        if (Number.isNaN(value.day)) missed.push('day');
+        fail(`missing ${missed.join(', ')}`, 'submit');
+        return;
+      }
+
+      const birthday = new Date(value.year, value.month - 1, value.day);
+      const today = new Date();
+      const age = today.getFullYear() - birthday.getFullYear();
+      const passed =
+        today.getMonth() > birthday.getMonth() ||
+        (today.getMonth() === birthday.getMonth() &&
+          today.getDate() >= birthday.getDate());
+      if (age < 20 || (age === 20 && !passed)) {
+        fail('must be at least 20 years old', 'blur');
+      }
+    }, [])
+  );
 
   return (
     <div>
-      <input type="text" ref={ref} />
+      <h2>Birthday</h2>
+      <label>
+        Year:
+        <NumberInput sugar={fields.year} />
+      </label>
+      <label>
+        Month:
+        <NumberInput sugar={fields.month} />
+      </label>
+      <label>
+        Day:
+        <NumberInput sugar={fields.day} />
+      </label>
+      <button
+        type="button"
+        onClick={async () => {
+          const result = await birthdaySugar.get(true);
+          console.log(result);
+        }}
+      >
+        get birthday
+      </button>
+      {errors.map((e, i) => (
+        <div key={i} className="error">
+          {e}
+        </div>
+      ))}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- close #15
- add `useValidation` hook with stage-aware fail and new event handling
- export new hook on Sugar instances
- write comprehensive tests for validation scenarios
- assert that errors are empty before submitting the form

## Testing
- `pnpm run format:check`
- `pnpm run lint`
- `pnpm run build`
- `pnpm vitest run --coverage`


------
https://chatgpt.com/codex/tasks/task_e_68472228809c8323bab1c2e4af115aa3