### PR TITLE
fix(core-unittest): React act warning in validation test

### DIFF
--- a/tests/core-unittest/src/useValidation.spec.tsx
+++ b/tests/core-unittest/src/useValidation.spec.tsx
@@ -77,8 +77,10 @@ describeWithStrict('Sugar#useValidation', () => {
 
     await act(async () => {});
 
-    await expect(sugar.current.get(true)).resolves.toStrictEqual({
-      result: 'validation_fault',
+    await act(async () => {
+      await expect(sugar.current.get(true)).resolves.toStrictEqual({
+        result: 'validation_fault',
+      });
     });
   });
 });


### PR DESCRIPTION
## Summary
- wrap async call in useValidation test with `act` to silence warnings

## Testing
- `pnpm run format:check`
- `pnpm run lint`
- `pnpm run build`
- `pnpm vitest run --coverage`

------
https://chatgpt.com/codex/tasks/task_e_6847be01c9d883238cd014cd65d17a7f